### PR TITLE
Different Build Environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
 jdk:
   - oraclejdk8
+env:
+  - BUILD_ENVIRONMENT=":ci"

--- a/softvis3d-frontend/pom.xml
+++ b/softvis3d-frontend/pom.xml
@@ -69,21 +69,12 @@
             </configuration>
           </execution>
           <execution>
-            <id>npm test</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <configuration>
-              <arguments>run test:coverage -- --reporter=spec</arguments>
-            </configuration>
-          </execution>
-          <execution>
             <id>npm build</id>
             <goals>
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>run build</arguments>
+              <arguments>run build${env.BUILD_ENVIRONMENT}</arguments>
             </configuration>
           </execution>
         </executions>

--- a/softvis3d-frontend/src/main/resources/package.json
+++ b/softvis3d-frontend/src/main/resources/package.json
@@ -11,6 +11,8 @@
     "start": "webpack-dev-server",
     "prebuild": "npm run lint -s && npm run test -s",
     "build": "npm run build:force -s",
+    "prebuild:ci": "npm run lint -s && npm run test:coverage -s",
+    "build:ci": "npm run build:force -s",
     "build:force": "webpack --progress --colors --prod",
     "lint": "tslint \"src/**/*.ts?(x)\" && shx echo \"[tslint] Lint successful\"",
     "test": "mocha",

--- a/softvis3d-frontend/src/main/resources/test/mocha.opts
+++ b/softvis3d-frontend/src/main/resources/test/mocha.opts
@@ -1,3 +1,3 @@
 --require ts-node/register
---reporter nyan
+--reporter spec
 test/**/*.spec.ts*


### PR DESCRIPTION
# Trigger
 * Travis runs the tests multiple times
 * Build Steps should not be configured in decentralized configs

# Changes
 * Default test reporter: **spec** (_bye bye nyan-cat_)
 * Removed test-step from frontend-build (maven) as it is already a fixture of `npm run build`
 * Created build-environment `build:ci` for additional coverage report and validation
 * Build-Environment can be configured with the system-environment-variable `BUILD_ENVIRONMENT` (see `.travis.yml`)

# Warning
While I'm confident with the changes, i was not able to test a local maven execution w/o the Environment-Variable. My conscience could rest easy, if you'd test a maven build, before merging the code. 👼 