### PR TITLE
Polishing

### DIFF
--- a/softvis3d-frontend/src/components/topbar/TopBarMenu.tsx
+++ b/softvis3d-frontend/src/components/topbar/TopBarMenu.tsx
@@ -11,8 +11,20 @@ export default class TopBarMenu extends React.Component<{ cityBuilderStore: City
     public render() {
         return (
             <div className="top-bar-menu">
-                <button className="left" onClick={this.showBuilder.bind(this)}>Settings</button>
-                <button className="right" onClick={this.showSettings.bind(this)}>Help</button>
+                <button
+                    className="left"
+                    onClick={this.showBuilder.bind(this)}
+                    disabled={this.props.cityBuilderStore.show}
+                >
+                    Settings
+                </button>
+
+                <button
+                    className="right"
+                    onClick={this.showSettings.bind(this)}
+                >
+                    Help
+                </button>
             </div>
         );
     }

--- a/softvis3d-frontend/src/components/visualization/Visualization.tsx
+++ b/softvis3d-frontend/src/components/visualization/Visualization.tsx
@@ -17,7 +17,11 @@ export default class Visualization extends React.Component<VisualizationProps, a
         const {cityBuilderStore, sceneStore} = this.props;
 
         if (!sceneStore.isVisible) {
-            return <div />;
+            return (
+                <div className="visualisation">
+                    <TopBar cityBuilderStore={cityBuilderStore} sceneStore={sceneStore}/>
+                </div>
+            );
         }
 
         return (

--- a/softvis3d-frontend/src/style/components/builder.scss
+++ b/softvis3d-frontend/src/style/components/builder.scss
@@ -32,7 +32,6 @@ $simpleCategoryHeight: 290px;
             height: 100%;
             background: #FFF center no-repeat;
             background-size: contain;
-            border: 1px dashed $gray-bright;
         }
 
         .layout-component {

--- a/softvis3d-frontend/src/style/components/scene.scss
+++ b/softvis3d-frontend/src/style/components/scene.scss
@@ -44,7 +44,7 @@
 
                 .value {
                     padding-left: 4px;
-                    color: $gray-dark;
+                    color: $gray-darkest;
 
                     &:before {content: "(";}
                     &:after {content: ")";}

--- a/softvis3d-frontend/src/style/mixins.scss
+++ b/softvis3d-frontend/src/style/mixins.scss
@@ -82,8 +82,14 @@
     }
 
     &:hover {
-        background: #236a97;
-        color: #fff;
+        background: $font-color-link-default;
+        color: $white;
+    }
+
+    &:disabled {
+        color: $font-color-link-hover;
+        background: transparent;
+        cursor: default;
     }
 }
 

--- a/softvis3d-frontend/test/components/visualization/Visualization.spec.tsx
+++ b/softvis3d-frontend/test/components/visualization/Visualization.spec.tsx
@@ -32,8 +32,12 @@ describe("<Visualization/>", () => {
             <Visualization cityBuilderStore={localCityBuilderStore} sceneStore={localSceneStore}/>
         );
 
-        expect(visualization.children()).to.have.length(0);
-        expect(visualization.find("div")).to.have.length(1);
+        expect(visualization.children()).to.have.length(1);
+
+        expect(visualization.contains(
+            <TopBar sceneStore={localSceneStore}
+                    cityBuilderStore={localCityBuilderStore}
+            />)).to.be.true;
     });
 
     it("should initialize all elements on start - shapes available but empty", () => {


### PR DESCRIPTION
 * Remove border from preview picture
 * Help button is always visible (because TopBar is always visible)
 * Settings button is disabled as long as CityBuilder is visible
 * Metric information in BottomBar / SceneInformation is darker (better to read)

Fixes 2 issues in #72 