### PR TITLE
Low Width issues

### DIFF
--- a/softvis3d-frontend/src/components/scene/visualization/SoftVis3dScene.ts
+++ b/softvis3d-frontend/src/components/scene/visualization/SoftVis3dScene.ts
@@ -118,7 +118,7 @@ export default class SoftVis3dScene {
         const sonarFooter = document.getElementById("footer");
         const sonarFooterHeight =  sonarFooter ? sonarFooter.offsetHeight : 11;
         const appMaxHeight = window.innerHeight - sonarFooterHeight - appOffset.top - (2 * sceneBoarderWidth);
-        const appMaxWidth = document.body.clientWidth - 2 * (appOffset.left + sceneBoarderWidth);
+        const appMaxWidth = Math.max(document.body.clientWidth - 2 * (appOffset.left + sceneBoarderWidth), 850);
 
         this.width = appMaxWidth - sidebarWidth - 1;
         this.height = appMaxHeight - topbarHeight;

--- a/softvis3d-frontend/src/components/scene/visualization/SoftVis3dScene.ts
+++ b/softvis3d-frontend/src/components/scene/visualization/SoftVis3dScene.ts
@@ -118,9 +118,9 @@ export default class SoftVis3dScene {
         const sonarFooter = document.getElementById("footer");
         const sonarFooterHeight =  sonarFooter ? sonarFooter.offsetHeight : 11;
         const appMaxHeight = window.innerHeight - sonarFooterHeight - appOffset.top - (2 * sceneBoarderWidth);
-        const appMaxWidth = Math.max(document.body.clientWidth - 2 * (appOffset.left + sceneBoarderWidth), 850);
+        const appComputedWidth = HtmlDom.getWidthById("app");
 
-        this.width = appMaxWidth - sidebarWidth - 1;
+        this.width = appComputedWidth - sidebarWidth - 1;
         this.height = appMaxHeight - topbarHeight;
 
         this.camera.setAspect(this.width, this.height);

--- a/softvis3d-frontend/src/components/scene/visualization/SoftVis3dScene.ts
+++ b/softvis3d-frontend/src/components/scene/visualization/SoftVis3dScene.ts
@@ -118,7 +118,7 @@ export default class SoftVis3dScene {
         const sonarFooter = document.getElementById("footer");
         const sonarFooterHeight =  sonarFooter ? sonarFooter.offsetHeight : 11;
         const appMaxHeight = window.innerHeight - sonarFooterHeight - appOffset.top - (2 * sceneBoarderWidth);
-        const appComputedWidth = HtmlDom.getWidthById("app");
+        const appComputedWidth = HtmlDom.getWidthById("app") - 2 * sceneBoarderWidth;
 
         this.width = appComputedWidth - sidebarWidth - 1;
         this.height = appMaxHeight - topbarHeight;

--- a/softvis3d-frontend/src/services/HtmlDom.ts
+++ b/softvis3d-frontend/src/services/HtmlDom.ts
@@ -28,7 +28,15 @@ export default class HtmlDom {
         }
 
         if (window.getComputedStyle) {
-            return parseInt(window.getComputedStyle(element).height || "0", 10);
+            const style = window.getComputedStyle(element);
+            let h = parseInt(style.height || "0", 10);
+            h += parseInt(style.paddingTop || "0", 10);
+            h += parseInt(style.paddingBottom || "0", 10);
+            h += parseInt(style.marginTop || "0", 10);
+            h += parseInt(style.marginBottom || "0", 10);
+            h += parseInt(style.borderTopWidth || "0", 10);
+            h += parseInt(style.borderBottomWidth || "0", 10);
+            return h;
         } else {
             return element.offsetHeight;
         }
@@ -42,7 +50,15 @@ export default class HtmlDom {
         }
 
         if (window.getComputedStyle) {
-            return parseInt(window.getComputedStyle(element).width || "0", 10);
+            const style = window.getComputedStyle(element);
+            let w = parseInt(style.width || "0", 10);
+            w += parseInt(style.paddingLeft || "0", 10);
+            w += parseInt(style.paddingRight || "0", 10);
+            w += parseInt(style.marginLeft || "0", 10);
+            w += parseInt(style.marginRight || "0", 10);
+            w += parseInt(style.borderLeftWidth || "0", 10);
+            w += parseInt(style.borderRightWidth || "0", 10);
+            return w;
         } else {
             return element.offsetWidth;
         }

--- a/softvis3d-frontend/src/services/HtmlDom.ts
+++ b/softvis3d-frontend/src/services/HtmlDom.ts
@@ -22,11 +22,29 @@ export default class HtmlDom {
 
     public static getHeightById(id: string): number {
         const element = document.getElementById(id);
-        return element ? element.offsetHeight : 0;
+
+        if (!element) {
+            return 0;
+        }
+
+        if (window.getComputedStyle) {
+            return parseInt(window.getComputedStyle(element).height || "0", 10);
+        } else {
+            return element.offsetHeight;
+        }
     }
 
     public static getWidthById(id: string): number {
         const element = document.getElementById(id);
-        return element ? element.offsetWidth : 0;
+
+        if (!element) {
+            return 0;
+        }
+
+        if (window.getComputedStyle) {
+            return parseInt(window.getComputedStyle(element).width || "0", 10);
+        } else {
+            return element.offsetWidth;
+        }
     }
 }

--- a/softvis3d-frontend/src/style/components/builder.scss
+++ b/softvis3d-frontend/src/style/components/builder.scss
@@ -81,7 +81,6 @@ $simpleCategoryHeight: 290px;
         }
 
         .right-column {
-            //position: absolute;
             float: right;
             width: 48%;
             height: 100%;

--- a/softvis3d-frontend/src/style/global.scss
+++ b/softvis3d-frontend/src/style/global.scss
@@ -119,7 +119,7 @@ body, #app {
 
 #app {
     @include clearfix;
-    min-width: 920px;
+    min-width: $dialog-width;
     background-color: $background-app;
     position: relative;
 }

--- a/softvis3d-frontend/src/style/measures.scss
+++ b/softvis3d-frontend/src/style/measures.scss
@@ -1,1 +1,1 @@
-$dialog-width: 920px;
+$dialog-width: 850px;

--- a/softvis3d-frontend/src/style/mixins.scss
+++ b/softvis3d-frontend/src/style/mixins.scss
@@ -16,7 +16,7 @@
     z-index: 5;
     width: $dialog-width;
     border: 1px solid $border-color-background;
-    margin: 15px auto;
+    margin: 36px auto;
     padding: 8px 10px 8px 10px;
     background-color: $white;
 


### PR DESCRIPTION
Fixes the issues with low window width mentioned in #72:
 * The scene now uses the computed height and width for elements.
 * Minimal width for the app has been reduced from 920px to 850px.
 * Dialogs are placed a few pixels lower, so they won't overlap the settings and help buttons