### PR TITLE
use "footprint" for descriptions, labels and properties (#77)

### DIFF
--- a/softvis3d-frontend/src/classes/Profile.ts
+++ b/softvis3d-frontend/src/classes/Profile.ts
@@ -7,9 +7,9 @@ export default class Profile implements SelectOptionValue {
     public id: string;
     public description: string;
     @observable
-    public metricHeight: Metric;
+    public height: Metric;
     @observable
-    public metricWidth: Metric;
+    public footprint: Metric;
     @observable
     public scale: Scale;
     private name: string;
@@ -17,8 +17,8 @@ export default class Profile implements SelectOptionValue {
     constructor(builder: ProfileBuilder) {
         this.id = builder.id;
         this.name = builder.name;
-        this.metricHeight = builder.metricHeight;
-        this.metricWidth = builder.metricWidth;
+        this.height = builder.height;
+        this.footprint = builder.footprint;
         this.scale = builder.scale;
         this.description = builder.description;
     }
@@ -31,15 +31,15 @@ export default class Profile implements SelectOptionValue {
         return this.name;
     }
 
-    public updateConfiguration(metricWidth: Metric, metricHeight: Metric, scale: Scale): void {
-        this.metricHeight = metricHeight;
-        this.metricWidth = metricWidth;
+    public updateConfiguration(footprint: Metric, height: Metric, scale: Scale): void {
+        this.height = height;
+        this.footprint = footprint;
         this.scale = scale;
     }
 
     public clone(): Profile {
         return new ProfileBuilder(this.id, this.name)
-            .withConfiguration(this.metricWidth, this.metricHeight, this.scale)
+            .withConfiguration(this.footprint, this.height, this.scale)
             .withDescription(this.description)
             .build();
     }
@@ -49,8 +49,8 @@ export class ProfileBuilder {
 
     public id: string;
     public name: string;
-    public metricHeight: Metric;
-    public metricWidth: Metric;
+    public height: Metric;
+    public footprint: Metric;
     public scale: Scale;
     public description: string;
 
@@ -59,9 +59,9 @@ export class ProfileBuilder {
         this.name = name;
     }
 
-    public withConfiguration(metricWidth: Metric, metricHeight: Metric, scale: Scale): ProfileBuilder {
-        this.metricHeight = metricHeight;
-        this.metricWidth = metricWidth;
+    public withConfiguration(footprint: Metric, height: Metric, scale: Scale): ProfileBuilder {
+        this.height = height;
+        this.footprint = footprint;
         this.scale = scale;
         return this;
     }

--- a/softvis3d-frontend/src/classes/VisualizationOptions.ts
+++ b/softvis3d-frontend/src/classes/VisualizationOptions.ts
@@ -14,16 +14,16 @@ export default class VisualizationOptions {
     }
 
     public layout: Layout;
-    public metricWidth: Metric;
-    public metricHeight: Metric;
+    public footprint: Metric;
+    public height: Metric;
     @observable
     public metricColor: ColorMetric;
     public scale: Scale;
 
-    constructor(layout: Layout, metricWidth: Metric, metricHeight: Metric, metricColor: ColorMetric, scale: Scale) {
+    constructor(layout: Layout, footprint: Metric, height: Metric, metricColor: ColorMetric, scale: Scale) {
         this.layout = layout;
-        this.metricWidth = metricWidth;
-        this.metricHeight = metricHeight;
+        this.footprint = footprint;
+        this.height = height;
         this.metricColor = metricColor;
         this.scale = scale;
     }

--- a/softvis3d-frontend/src/components/citybuilder/OptionsAdvanced.tsx
+++ b/softvis3d-frontend/src/components/citybuilder/OptionsAdvanced.tsx
@@ -16,23 +16,23 @@ export default class OptionsAdvanced extends React.Component<{ store: CityBuilde
                 <div className="left-column">
                     <div className="builder-option">
                         <SelectBoxBuilder
-                            label="Metric - Base"
-                            value={this.props.store.profile.metricWidth}
+                            label="Metric - Footprint"
+                            value={this.props.store.profile.footprint}
                             options={this.props.store.genericMetrics.asSelectOptions}
                             onChange={(m: Metric) => {
                                 this.props.store.profile = custom;
-                                this.props.store.profile.metricWidth = m;
+                                this.props.store.profile.footprint = m;
                             }}
                         />
                     </div>
                     <div className="builder-option">
                     <SelectBoxBuilder
                             label="Metric - Height"
-                            value={this.props.store.profile.metricHeight}
+                            value={this.props.store.profile.height}
                             options={this.props.store.genericMetrics.asSelectOptions}
                             onChange={(m: Metric) => {
                                 this.props.store.profile = custom;
-                                this.props.store.profile.metricHeight = m;
+                                this.props.store.profile.height = m;
                             }}
                         />
                     </div>
@@ -49,7 +49,7 @@ export default class OptionsAdvanced extends React.Component<{ store: CityBuilde
                         />
                     </div>
                     <p className="selection-description profile-description">
-                        Change how the metric values will be scaled for width and height.
+                        Change how the metric values will be scaled for footprint and height.
                     </p>
                 </div>
             </Category>

--- a/softvis3d-frontend/src/components/scene/information/SceneInformation.tsx
+++ b/softvis3d-frontend/src/components/scene/information/SceneInformation.tsx
@@ -25,8 +25,8 @@ export default class SceneInformation extends React.Component<SceneInformationPr
 
         return (
             <div className="scene-information">
-                <MetricKey title="Width" metric={sceneStore.options.metricWidth} selectedElement={selectedElement}/>
-                <MetricKey title="Height" metric={sceneStore.options.metricHeight} selectedElement={selectedElement}/>
+                <MetricKey title="Footprint" metric={sceneStore.options.footprint} selectedElement={selectedElement}/>
+                <MetricKey title="Height" metric={sceneStore.options.height} selectedElement={selectedElement}/>
                 <SelectBoxBuilder
                     label="Color"
                     className="metric-info"

--- a/softvis3d-frontend/src/constants/Profiles.ts
+++ b/softvis3d-frontend/src/constants/Profiles.ts
@@ -4,7 +4,7 @@ import Profile, { ProfileBuilder } from "../classes/Profile";
 
 const defaultProfile: Profile = new ProfileBuilder("default", "Default")
     .withConfiguration(Metric.complexityMetric, Metric.linesOfCodeMetric, LayoutProcessor.SCALING_METHODS[0])
-    .withDescription("Default risk analysis profile. Complexity as building width and lines of code as building" +
+    .withDescription("Default risk analysis profile. Complexity as building footprint and lines of code as building" +
         " height provide a very good overview of the structure of your project. It should be easy to identify the " +
         "classes or packages with the highest risks. Change the building color to take a closer look at the " +
         "interesting parts.")

--- a/softvis3d-frontend/src/legacy/LayoutProcessor.ts
+++ b/softvis3d-frontend/src/legacy/LayoutProcessor.ts
@@ -41,7 +41,7 @@ interface MinMaxValue {
 }
 
 export interface MetricScale {
-    metricHeight: MinMaxValue;
+    height: MinMaxValue;
     metricFootprint: MinMaxValue;
     metricColor: MinMaxValue;
 }
@@ -67,7 +67,7 @@ class LayoutProcessor {
         this._illustrator = null;
         this._rules = [];
         this._metricScale = {
-            metricHeight: {min: Infinity, max: 0},
+            height: {min: Infinity, max: 0},
             metricFootprint: {min: Infinity, max: 0},
             metricColor: {min: Infinity, max: 0}
         };
@@ -202,7 +202,7 @@ class LayoutProcessor {
         let base: number;
 
         if (this._options.scalingMethod === "logarithmic") {
-            if (this._metricScale.metricHeight.max > 1400) {
+            if (this._metricScale.height.max > 1400) {
                 // Logarithmic Max: ~2300 ==> 450
                 base = 5;
                 power = 3.89;
@@ -217,7 +217,7 @@ class LayoutProcessor {
                 condition: (model: Softvis3dModel, node: TreeNodeInterface) => model && node.children.length === 0,
                 metric: (model, node, version) => {
                     const attr: AttributeContainer = attributeHelper.attrFallbackSweep(model, node, version);
-                    return ("metricHeight" in attr) ? attr["metricHeight"] : 0;
+                    return ("height" in attr) ? attr["height"] : 0;
                 },
                 attributes: "dimensions.height",
                 min: 6,
@@ -227,13 +227,13 @@ class LayoutProcessor {
             });
         } else if (this._options.scalingMethod === "exponential") {
             factor = 0.5;
-            power = Math.log(max / factor) / Math.log(this._metricScale.metricHeight.max);
+            power = Math.log(max / factor) / Math.log(this._metricScale.height.max);
 
             return new CodeCityVis.rules.math.exponential({
                 condition: (model: Softvis3dModel, node: TreeNodeInterface) => model && node.children.length === 0,
                 metric: (model, node, version) => {
                     const attr = attributeHelper.attrFallbackSweep(model, node, version);
-                    return ("metricHeight" in attr) ? attr["metricHeight"] : 0;
+                    return ("height" in attr) ? attr["height"] : 0;
                 },
                 attributes: "dimensions.height",
                 min: 6,
@@ -249,15 +249,15 @@ class LayoutProcessor {
                 max = Infinity;
             }
 
-            if (this._metricScale.metricHeight.max > max) {
-                factor = max / this._metricScale.metricHeight.max;
+            if (this._metricScale.height.max > max) {
+                factor = max / this._metricScale.height.max;
             }
 
             return new CodeCityVis.rules.math.linear({
                 condition: (model, node) => model && node.children.length === 0,
                 metric: (model, node, version) => {
                     const attr = attributeHelper.attrFallbackSweep(model, node, version);
-                    return ("metricHeight" in attr) ? attr["metricHeight"] : 0;
+                    return ("height" in attr) ? attr["height"] : 0;
                 },
                 attributes: "dimensions.height",
                 min: 6,

--- a/softvis3d-frontend/src/legacy/LegacyConnector.ts
+++ b/softvis3d-frontend/src/legacy/LegacyConnector.ts
@@ -23,8 +23,8 @@ export default class LegacyConnector {
         if (this.sceneStore.legacyData !== null) {
             this.appStatusStore.load(LegacyConnector.BUILD_CITY);
 
-            const model = new Softvis3dModel(this.sceneStore.legacyData, this.sceneStore.options.metricWidth.id,
-                this.sceneStore.options.metricHeight.id, this.sceneStore.options.metricColor.id);
+            const model = new Softvis3dModel(this.sceneStore.legacyData, this.sceneStore.options.footprint.id,
+                this.sceneStore.options.height.id, this.sceneStore.options.metricColor.id);
 
             const options = {
                 layout: this.sceneStore.options.layout.id,

--- a/softvis3d-frontend/src/legacy/Softvis3dModel.ts
+++ b/softvis3d-frontend/src/legacy/Softvis3dModel.ts
@@ -35,11 +35,11 @@ export default class Softvis3dModel extends BaseModel {
     private _graph: any[];
     private _tree: TreeNodeInterface;
     private _metricScale: MetricScale;
-    private _metricWidthKey :string;
-    private _metricHeightKey :string;
+    private _footprintKey :string;
+    private _heightKey :string;
     private _metricColorKey :string;
 
-    constructor(treeResult: TreeElement, metricWidthKey: string, metricHeightKey: string, metricColorKey: string) {
+    constructor(treeResult: TreeElement, footprintKey: string, heightKey: string, metricColorKey: string) {
         super();
 
         this._attributes = {};
@@ -47,13 +47,13 @@ export default class Softvis3dModel extends BaseModel {
         this._versions = [ this._version ];
         this._graph = [];
         this._metricScale = {
-            metricHeight: {min: Infinity, max: 0},
+            height: {min: Infinity, max: 0},
             metricFootprint: {min: Infinity, max: 0},
             metricColor: {min: Infinity, max: 0}
         };
 
-        this._metricWidthKey = metricWidthKey;
-        this._metricHeightKey = metricHeightKey;
+        this._footprintKey = footprintKey;
+        this._heightKey = heightKey;
         this._metricColorKey = metricColorKey;
 
         this._tree = this._createTree(treeResult);
@@ -69,20 +69,20 @@ export default class Softvis3dModel extends BaseModel {
 
         this._attributes[v][t] = {
             'name': t,
-            'metricHeight' : this.getMetricValue(treeNode, this._metricHeightKey),
-            'metricFootprint' : this.getMetricValue(treeNode, this._metricWidthKey),
+            'height' : this.getMetricValue(treeNode, this._heightKey),
+            'metricFootprint' : this.getMetricValue(treeNode, this._footprintKey),
             'metricColor' : this.getMetricValue(treeNode, this._metricColorKey)
         };
 
 
-        if (this.isMetricValueSet(treeNode, this._metricHeightKey)) {
-            this._metricScale.metricHeight.min = Math.min(treeNode.measures[this._metricHeightKey], this._metricScale.metricHeight.min);
-            this._metricScale.metricHeight.max = Math.max(treeNode.measures[this._metricHeightKey], this._metricScale.metricHeight.max);
+        if (this.isMetricValueSet(treeNode, this._heightKey)) {
+            this._metricScale.height.min = Math.min(treeNode.measures[this._heightKey], this._metricScale.height.min);
+            this._metricScale.height.max = Math.max(treeNode.measures[this._heightKey], this._metricScale.height.max);
         }
 
-        if (this.isMetricValueSet(treeNode, this._metricWidthKey)) {
-            this._metricScale.metricFootprint.min = Math.min(treeNode.measures[this._metricWidthKey], this._metricScale.metricFootprint.min);
-            this._metricScale.metricFootprint.max = Math.max(treeNode.measures[this._metricWidthKey], this._metricScale.metricFootprint.max);
+        if (this.isMetricValueSet(treeNode, this._footprintKey)) {
+            this._metricScale.metricFootprint.min = Math.min(treeNode.measures[this._footprintKey], this._metricScale.metricFootprint.min);
+            this._metricScale.metricFootprint.max = Math.max(treeNode.measures[this._footprintKey], this._metricScale.metricFootprint.max);
         }
 
         if (this.isMetricValueSet(treeNode, this._metricColorKey)) {

--- a/softvis3d-frontend/src/reactions/BuilderReactions.ts
+++ b/softvis3d-frontend/src/reactions/BuilderReactions.ts
@@ -25,8 +25,8 @@ export default class BuilderReactions {
 
                     // Transfer values
                     this.scene.options =
-                        new VisualizationOptions(this.builder.layout, this.builder.profile.metricWidth,
-                            this.builder.profile.metricHeight, this.builder.metricColor, this.builder.profile.scale);
+                        new VisualizationOptions(this.builder.layout, this.builder.profile.footprint,
+                            this.builder.profile.height, this.builder.metricColor, this.builder.profile.scale);
 
                     this.scene.refreshScene = true;
                 }

--- a/softvis3d-frontend/src/services/sonarqube/SonarQubeLegacyService.ts
+++ b/softvis3d-frontend/src/services/sonarqube/SonarQubeLegacyService.ts
@@ -73,8 +73,8 @@ export default class SonarQubeLegacyService extends BackendService {
 
     private getMetricRequestValues(): string {
         let result: Set<string> = new Set();
-        result.add(this.cityBuilderStore.profile.metricWidth.id);
-        result.add(this.cityBuilderStore.profile.metricHeight.id);
+        result.add(this.cityBuilderStore.profile.footprint.id);
+        result.add(this.cityBuilderStore.profile.height.id);
 
         for (const colorMetric of this.cityBuilderStore.colorMetrics.keys) {
             if (colorMetric !== "none" && colorMetric !== "package") {

--- a/softvis3d-frontend/src/services/sonarqube/SonarQubeMetricsService.ts
+++ b/softvis3d-frontend/src/services/sonarqube/SonarQubeMetricsService.ts
@@ -93,7 +93,7 @@ export default class SonarQubeMetricsService extends BackendService {
 
     private checkNewLinesOfCodeMetric() {
         if (!this.cityBuilderStore.genericMetrics.hasNewLinesOfCodeMetric) {
-            leakPeriod.metricHeight = newLinesToCoverMetric;
+            leakPeriod.height = newLinesToCoverMetric;
         }
     }
 

--- a/softvis3d-frontend/src/stores/CityBuilderStore.ts
+++ b/softvis3d-frontend/src/stores/CityBuilderStore.ts
@@ -30,7 +30,7 @@ class CityBuilderStore {
 
     set profile(p: Profile) {
         if (p.id === custom.id) {
-            this._customProfile.updateConfiguration(this.profile.metricWidth, this.profile.metricHeight, this.profile.scale);
+            this._customProfile.updateConfiguration(this.profile.footprint, this.profile.height, this.profile.scale);
             this._profile = this._customProfile;
         } else {
             this._profile = Profiles.getAvailableProfileById(p.id).clone();

--- a/softvis3d-frontend/test/classes/Profile.spec.ts
+++ b/softvis3d-frontend/test/classes/Profile.spec.ts
@@ -35,8 +35,8 @@ describe("Profile", () => {
             .build();
 
         expect(profile.id).to.be.eq(expectedId);
-        expect(profile.metricWidth).to.be.eq(Metric.complexityMetric);
-        expect(profile.metricHeight).to.be.eq(Metric.linesOfCodeMetric);
+        expect(profile.footprint).to.be.eq(Metric.complexityMetric);
+        expect(profile.height).to.be.eq(Metric.linesOfCodeMetric);
         expect(profile.scale).to.be.eq(LayoutProcessor.SCALING_METHODS[0]);
 
         expect(profile.description).to.be.eq(expectedDescription);
@@ -74,8 +74,8 @@ describe("Profile", () => {
 
         expect(cloneResult.id).to.be.eq(id);
         expect(cloneResult.getLabel()).to.be.eq(name);
-        expect(cloneResult.metricWidth).to.be.eq(metricWidth);
-        expect(cloneResult.metricHeight).to.be.eq(metricHeight);
+        expect(cloneResult.footprint).to.be.eq(metricWidth);
+        expect(cloneResult.height).to.be.eq(metricHeight);
         expect(cloneResult.scale).to.be.eq(scalingmethod);
         expect(cloneResult.description).to.be.eq(description);
     });
@@ -101,8 +101,8 @@ describe("Profile", () => {
 
         expect(test.id).to.be.eq(id);
         expect(test.getLabel()).to.be.eq(name);
-        expect(test.metricWidth).to.be.eq(updateMetricWidth);
-        expect(test.metricHeight).to.be.eq(updateMetricHeight);
+        expect(test.footprint).to.be.eq(updateMetricWidth);
+        expect(test.height).to.be.eq(updateMetricHeight);
         expect(test.scale).to.be.eq(updateScale);
         expect(test.description).to.be.eq(description);
     });

--- a/softvis3d-frontend/test/classes/VisualizationOptions.spec.ts
+++ b/softvis3d-frontend/test/classes/VisualizationOptions.spec.ts
@@ -34,17 +34,17 @@ describe("VisualizationOptions", () => {
         let metricWidth: Metric = complexityMetric;
         let metricHeight: Metric = linesOfCodeMetric;
         let metricColor: ColorMetric = coverageMetric;
-        let scalingmethod: Scale = LayoutProcessor.SCALING_METHODS[0];
+        let scalingMethod: Scale = LayoutProcessor.SCALING_METHODS[0];
         let layout: Layout = evostreet;
 
         let result: VisualizationConfiguration =
-            new VisualizationConfiguration(layout, metricWidth, metricHeight, metricColor, scalingmethod);
+            new VisualizationConfiguration(layout, metricWidth, metricHeight, metricColor, scalingMethod);
 
         expect(result.layout).to.be.eq(layout);
-        expect(result.metricWidth).to.be.eq(metricWidth);
-        expect(result.metricHeight).to.be.eq(metricHeight);
+        expect(result.footprint).to.be.eq(metricWidth);
+        expect(result.height).to.be.eq(metricHeight);
         expect(result.metricColor).to.be.eq(metricColor);
-        expect(result.scale).to.be.eq(scalingmethod);
+        expect(result.scale).to.be.eq(scalingMethod);
     });
 
     it("should create default config", () => {
@@ -57,8 +57,8 @@ describe("VisualizationOptions", () => {
         let result: VisualizationConfiguration = VisualizationConfiguration.createDefault();
 
         expect(result.layout).to.be.eq(layout);
-        expect(result.metricWidth).to.be.eq(metricWidth);
-        expect(result.metricHeight).to.be.eq(metricHeight);
+        expect(result.footprint).to.be.eq(metricWidth);
+        expect(result.height).to.be.eq(metricHeight);
         expect(result.metricColor).to.be.eq(metricColor);
         expect(result.scale).to.be.eq(scalingmethod);
     });

--- a/softvis3d-frontend/test/components/scene/information/SceneInformation.spec.tsx
+++ b/softvis3d-frontend/test/components/scene/information/SceneInformation.spec.tsx
@@ -16,12 +16,12 @@ describe("<SceneInformation/>", () => {
 
         expect(bottomBar
             .contains(<MetricKey
-                title="Width"
-                metric={sceneStore.options.metricWidth}
+                title="Footprint"
+                metric={sceneStore.options.footprint}
                 selectedElement={testSceneStore.selectedElement}
             />)).to.be.true;
 
-        expect(bottomBar.children().length).to.be.eq(3);
+        expect(bottomBar.children()).to.be.length(3);
     });
 
 });

--- a/softvis3d-frontend/test/reactions/BuilderReactions.spec.ts
+++ b/softvis3d-frontend/test/reactions/BuilderReactions.spec.ts
@@ -33,10 +33,11 @@ describe("BuilderReactions", () => {
         let testSceneStore = new SceneStore();
         testSceneStore.shapes = {};
 
-        new BuilderReactions(testCityBuilderStore, testSceneStore);
+        const reactionRegister = new BuilderReactions(testCityBuilderStore, testSceneStore);
 
         testCityBuilderStore.initiateBuildProcess = true;
 
+        expect(reactionRegister).not.to.be.null;
         expect(testSceneStore.shapes).to.be.null;
         expect(testCityBuilderStore.initiateBuildProcess).to.be.false;
         expect(testSceneStore.refreshScene).to.be.true;
@@ -56,14 +57,15 @@ describe("BuilderReactions", () => {
         testCityBuilderStore.profile.scale = expectedScale;
         testCityBuilderStore.metricColor = expectedColorMetric;
 
-        new BuilderReactions(testCityBuilderStore, testSceneStore);
+        const reactionRegister = new BuilderReactions(testCityBuilderStore, testSceneStore);
 
         testCityBuilderStore.initiateBuildProcess = true;
 
+        expect(reactionRegister).not.to.be.null;
         expect(testSceneStore.options.layout).to.be.eq(expectedLayout);
         expect(testSceneStore.options.metricColor).to.be.eq(expectedColorMetric);
-        expect(testSceneStore.options.metricWidth).to.be.eq(expectedProfile.metricWidth);
-        expect(testSceneStore.options.metricHeight).to.be.eq(expectedProfile.metricHeight);
+        expect(testSceneStore.options.footprint).to.be.eq(expectedProfile.footprint);
+        expect(testSceneStore.options.height).to.be.eq(expectedProfile.height);
         expect(testSceneStore.options.scale).to.be.eq(expectedScale);
     });
 

--- a/softvis3d-frontend/test/services/sonarqube/SonarQubeMetricsService.spec.ts
+++ b/softvis3d-frontend/test/services/sonarqube/SonarQubeMetricsService.spec.ts
@@ -60,7 +60,7 @@ describe("SonarQubeMetricsService", () => {
         clock.tick(10);
         returnPromise.then(() => {
             Sinon.assert.called(spyAdd);
-            expect(leakPeriod.metricHeight).to.be.eq(newLinesToCoverMetric);
+            expect(leakPeriod.height).to.be.eq(newLinesToCoverMetric);
             done();
         }).catch((error) => done(error));
     });

--- a/softvis3d-frontend/test/stores/CityBuilderStore.spec.ts
+++ b/softvis3d-frontend/test/stores/CityBuilderStore.spec.ts
@@ -66,8 +66,8 @@ describe("CityBuilderStore", () => {
         underTest.profile = leakPeriod;
         underTest.profile = custom;
         expect(underTest.profile.id).to.be.equal(custom.id);
-        expect(leakPeriod.metricHeight).to.be.equal(custom.metricHeight);
-        expect(leakPeriod.metricWidth).to.be.equal(custom.metricWidth);
+        expect(leakPeriod.height).to.be.equal(custom.height);
+        expect(leakPeriod.footprint).to.be.equal(custom.footprint);
         expect(leakPeriod.scale).to.be.equal(custom.scale);
     });
 


### PR DESCRIPTION
All occurrences of "width" or "base" in correlation with building properties have been changed to footprint. This includes
 * Source Code (variable names, fields / properties, parameter names)
 * Descriptions (Profile- and Metric metric descriptions)
 * UI (headlines and labels)